### PR TITLE
Add Arch Linux installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ brew tap laravel/moat https://github.com/laravel/moat
 brew install laravel/moat/moat
 ```
 
+### Arch Linux
+
+Install from the [AUR](https://aur.archlinux.org/packages/laravel-moat):
+
+```bash
+yay -S laravel-moat
+# or
+paru -S laravel-moat
+```
+
 ### Prebuilt binaries
 
 Download the archive for your platform from the [releases page](https://github.com/laravel/moat/releases) and place `moat` on your `PATH`.


### PR DESCRIPTION
Hi,

Firstly, thank you for this wonderful and very useful project.

I wanted an easier way to install on Arch Linux (Omarchy, Cachy et. al.) and so I've created an AUR so that Arch users can install moat via a package manager and keep it up to date:

https://aur.archlinux.org/packages/laravel-moat
https://github.com/Jamesking56/laravel-moat-aur

It is automatically kept in sync with releases in this repo hourly, it does checksum checks to ensure that the file downloaded matches the checksums in GitHub releases in this repo.

I will maintain it going forwards (for my own needs anyway).

This PR adds the Arch AUR install instructions to the README for Arch users.