### PR TITLE
fix: add missing space before colon to avoid broken redirect URL

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -585,7 +585,7 @@ pub fn format_no_token_error(detail: &str) -> AuthError {
             AuthErrorLine::Blank,
             AuthErrorLine::Numbered(
                 2,
-                "Or set a personal access token from https://github.com/settings/tokens:"
+                "Or set a personal access token from https://github.com/settings/tokens :"
                     .to_string(),
             ),
             AuthErrorLine::Code("export GITHUB_TOKEN=<your-token>".to_string()),


### PR DESCRIPTION
## Fix broken URL in terminal output

### What
Added a space after the URL `https://github.com/settings/tokens` in the suggested fix message.

### Why
When running `moat <account>` without any GitHub auth configured, Moat prints an error message suggesting to set a personal access token from `https://github.com/settings/tokens`. However, the URL was immediately followed by a colon (`:`) with no space, causing terminals to include the colon in the hyperlink on Ctrl+Click. This redirected users to `https://github.com/settings/tokens:` which returns a 404 error.

### Before / After
- **Before:** `https://github.com/settings/tokens:`  ← colon included in the link
- **After:** `https://github.com/settings/tokens` `:`  ← colon excluded