### PR TITLE
fix: correct two-factor disabled members URL

### DIFF
--- a/src/checks/organization_members_all_have_two_factor.rs
+++ b/src/checks/organization_members_all_have_two_factor.rs
@@ -4,7 +4,7 @@ use crate::checks::org_context::OrgContext;
 use crate::support::outcome::CheckOutcome;
 
 pub const LABEL: &str = "Organization members all have two factor";
-pub const HOW_TO_FIX: &str = "https://github.com/orgs/{org}/people?query=2fa%3Adisabled > Ask each listed member to enable 2FA on their GitHub account";
+pub const HOW_TO_FIX: &str = "https://github.com/orgs/{org}/people?query=two-factor%3Adisabled > Ask each listed member to enable 2FA on their GitHub account";
 pub const WHY_ENABLE: &str = "The org-wide 2FA policy only covers members enrolled after it was turned on; anyone here predates it and remains the weakest unlocked door into the org.";
 
 pub fn how_to_fix(_ctx: StateCtx<'_>) -> &'static str {


### PR DESCRIPTION
Correct the GitHub organization people search URL for members without 2FA.

GitHub expects `two-factor:disabled`, not `2fa:disabled`.