### PR TITLE
feat(workflow-permissions): :sparkles: Add known action exemptions for workflow permission checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ Pinning refs by hand isn't enough — anyone can later reintroduce a mutable `@v
 
 Without a declared `permissions:` block (or with `write-all`), every step in the workflow — including third-party actions — runs with full repo write access, turning any compromised action into a code-push primitive.
 
+Actions known to require write permissions (e.g. `actions/deploy-pages` needing `pages: write`) are automatically exempted. Add additional known actions per-repo via `[workflow_permissions]` in `moat.toml` — see [Configuration](#configuration).
+
 ### `repositories_have_security_policy`
 
 Without a disclosure channel, well-meaning researchers file public issues with full PoCs — `SECURITY.md` is what funnels them to a private channel before the world sees the bug.
@@ -186,6 +188,16 @@ You can also declare additional release branches that should be treated as prote
 ```toml
 release_branches = ["0.x", "1.x"]
 ```
+
+For the `repositories_workflow_permissions_are_restricted` check, you can declare actions whose job-level write scopes are known to be required. When a job uses one of these actions, its matching write scopes are exempted from the check. This is useful for deployment actions that legitimately need scopes like `pages: write` or `id-token: write`.
+
+```toml
+[workflow_permissions]
+"actions/deploy-pages" = ["pages", "id-token"]
+"aws-actions/configure-aws-credentials" = ["id-token"]
+```
+
+`actions/deploy-pages` is recognised out of the box; entries in `[workflow_permissions]` extend or override the built-in list.
 
 ## Checks skipped on GitHub Free
 

--- a/src/checks/repositories_workflow_permissions_are_restricted.rs
+++ b/src/checks/repositories_workflow_permissions_are_restricted.rs
@@ -1,15 +1,18 @@
 use crate::checks::StateCtx;
 use crate::checks::common::{noun, repos_word};
 use crate::checks::repo_context::RepoContext;
+use crate::config::Config;
 use crate::support::outcome::CheckOutcome;
 use crate::support::workflows::{self, PermissionsBlock, Workflow};
+use serde_yaml::Value;
 
 pub const LABEL: &str = "Repositories workflow permissions are restricted";
 pub const HOW_TO_FIX: &str = "In each `.github/workflows/*.yml` below > *Add* -> A top-level `permissions:` block > *Set* -> The minimum scopes needed — for read-only workflows:\n```yaml\npermissions:\n  contents: read\n```";
 pub const WHY_ENABLE: &str = "Without a declared `permissions:` block (or with `write-all`), every step in the workflow — including third-party actions — runs with full repo write access, turning any compromised action into a code-push primitive.";
 
-fn findings_for_workflows(wfs: &[Workflow]) -> Vec<String> {
+fn findings_for_workflows(wfs: &[Workflow], config: &Config) -> (Vec<String>, bool) {
     let mut findings: Vec<String> = Vec::new();
+    let mut had_filtered_writes = false;
     for wf in wfs {
         match workflows::top_level_permissions(&wf.doc) {
             PermissionsBlock::Missing => {
@@ -27,18 +30,44 @@ fn findings_for_workflows(wfs: &[Workflow]) -> Vec<String> {
                     findings.push(format!("{}: job `{}` write-all", wf.path, job));
                 }
                 PermissionsBlock::Scoped(writes) if !writes.is_empty() => {
-                    findings.push(format!(
-                        "{}: job `{}` write scopes [{}]",
-                        wf.path,
-                        job,
-                        writes.join(", ")
-                    ));
+                    let writes_to_report = filter_job_writes(&wf.doc, &job, &writes, config);
+                    if !writes_to_report.is_empty() {
+                        findings.push(format!(
+                            "{}: job `{}` write scopes [{}]",
+                            wf.path,
+                            job,
+                            writes_to_report.join(", ")
+                        ));
+                    } else {
+                        had_filtered_writes = true;
+                    }
                 }
                 _ => {}
             }
         }
     }
-    findings
+    (findings, had_filtered_writes)
+}
+
+fn known_action_matches<'a>(uses: &'a str, config: &'a Config) -> Option<Vec<&'a str>> {
+    let action = uses.split('@').next().unwrap_or(uses);
+    if action.starts_with("./") || action.starts_with("docker://") {
+        return None;
+    }
+    config.known_action_writes(action)
+}
+
+fn filter_job_writes<'a>(doc: &Value, job: &str, writes: &[&'a str], config: &Config) -> Vec<&'a str> {
+    for uses in workflows::job_action_uses(doc, job) {
+        if let Some(allowed) = known_action_matches(&uses, config) {
+            return writes
+                .iter()
+                .filter(|w| !allowed.contains(w))
+                .copied()
+                .collect();
+        }
+    }
+    writes.to_vec()
 }
 
 pub fn how_to_fix(_ctx: StateCtx<'_>) -> &'static str {
@@ -57,7 +86,7 @@ pub fn repo_check(ctx: &RepoContext) -> CheckOutcome {
     let mut all_findings: Vec<String> = Vec::new();
     let mut failing_branches: Vec<String> = Vec::new();
     for (branch, wfs) in ctx.workflows.iter() {
-        let findings = findings_for_workflows(wfs);
+        let (findings, _) = findings_for_workflows(wfs, &ctx.config);
         if findings.is_empty() {
             continue;
         }
@@ -80,6 +109,7 @@ pub fn repo_check(ctx: &RepoContext) -> CheckOutcome {
 pub fn description(ctx: StateCtx<'_>) -> Option<String> {
     let mut total_bad = 0usize;
     let mut bad_repos = 0usize;
+    let mut total_exempted_workflows = 0usize;
     let mut applicable = 0usize;
     for r in ctx.repos {
         if !r.workflows.has_any_workflows() {
@@ -87,6 +117,7 @@ pub fn description(ctx: StateCtx<'_>) -> Option<String> {
         }
         applicable += 1;
         let mut repo_bad = 0usize;
+        let mut repo_exempted = 0usize;
         for (_, wfs) in r.workflows.iter() {
             for wf in wfs {
                 let top_bad = match workflows::top_level_permissions(&wf.doc) {
@@ -94,15 +125,35 @@ pub fn description(ctx: StateCtx<'_>) -> Option<String> {
                     PermissionsBlock::Scoped(w) if !w.is_empty() => true,
                     _ => false,
                 };
-                let job_bad =
+                let (job_bad, job_exempted) =
                     workflows::job_level_permissions(&wf.doc)
                         .into_iter()
-                        .any(|(_, b)| {
-                            matches!(b, PermissionsBlock::WriteAll)
-                                || matches!(b, PermissionsBlock::Scoped(w) if !w.is_empty())
+                        .fold((false, false), |(bad, exempted), (job, b)| {
+                            let has_writes = match &b {
+                                PermissionsBlock::WriteAll => true,
+                                PermissionsBlock::Scoped(w) if !w.is_empty() => true,
+                                _ => false,
+                            };
+                            if !has_writes {
+                                return (bad, exempted);
+                            }
+                            let remaining = match &b {
+                                PermissionsBlock::Scoped(w) if !w.is_empty() => {
+                                    filter_job_writes(&wf.doc, &job, w, &r.config)
+                                }
+                                _ => vec![],
+                            };
+                            if remaining.is_empty() && !matches!(b, PermissionsBlock::WriteAll) {
+                                (bad, true)
+                            } else {
+                                (true, exempted)
+                            }
                         });
                 if top_bad || job_bad {
                     repo_bad += 1;
+                }
+                if job_exempted {
+                    repo_exempted += 1;
                 }
             }
         }
@@ -110,21 +161,40 @@ pub fn description(ctx: StateCtx<'_>) -> Option<String> {
             bad_repos += 1;
             total_bad += repo_bad;
         }
+        if repo_exempted > 0 && repo_bad == 0 {
+            total_exempted_workflows += repo_exempted;
+        }
     }
 
     if applicable == 0 {
         return None;
     }
     Some(if total_bad == 0 {
-        format!(
+        let base = format!(
             "every workflow declares a read-only permissions block across all {applicable} {} with workflows",
             repos_word(applicable)
-        )
+        );
+        if total_exempted_workflows > 0 {
+            format!(
+                "{base} ({total_exempted_workflows} {} with known-action exemptions)",
+                noun(total_exempted_workflows, "workflow", "workflows"),
+            )
+        } else {
+            base
+        }
     } else {
-        format!(
+        let base = format!(
             "{total_bad} {} grant write or omit the permissions block across {bad_repos}/{applicable} {} with workflows",
             noun(total_bad, "workflow", "workflows"),
             repos_word(applicable)
-        )
+        );
+        if total_exempted_workflows > 0 {
+            format!(
+                "{base}; {total_exempted_workflows} {} exempted for known actions",
+                noun(total_exempted_workflows, "workflow", "workflows"),
+            )
+        } else {
+            base
+        }
     })
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,15 @@ impl std::error::Error for InvalidConfigError {
 pub struct Config {
     checks: HashMap<String, CheckState>,
     release_branches: Vec<String>,
+    workflow_permissions_known_actions: HashMap<String, Vec<String>>,
+}
+
+/// Built-in actions whose job-level write scopes are known to be required.
+/// Users can extend or override these in `moat.toml` under `[workflow_permissions]`.
+pub fn builtin_known_actions() -> HashMap<&'static str, Vec<&'static str>> {
+    let mut m = HashMap::new();
+    m.insert("actions/deploy-pages", vec!["pages", "id-token"]);
+    m
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -49,6 +58,8 @@ struct RawConfig {
     checks: HashMap<String, String>,
     #[serde(default)]
     release_branches: Vec<String>,
+    #[serde(default)]
+    workflow_permissions: HashMap<String, Vec<String>>,
 }
 
 impl Config {
@@ -71,6 +82,7 @@ impl Config {
         Ok(Self {
             checks,
             release_branches: raw.release_branches,
+            workflow_permissions_known_actions: raw.workflow_permissions,
         })
     }
 
@@ -80,6 +92,20 @@ impl Config {
 
     pub fn release_branches(&self) -> &[String] {
         &self.release_branches
+    }
+
+    /// Look up the write scopes that are known to be required by a given action.
+    /// Built-in defaults are always present; user config entries override when
+    /// the same action prefix is specified.
+    pub fn known_action_writes(&self, action_uses: &str) -> Option<Vec<&str>> {
+        // User config takes precedence
+        if let Some(writes) = self.workflow_permissions_known_actions.get(action_uses) {
+            return Some(writes.iter().map(|s| s.as_str()).collect());
+        }
+        // Fall back to built-in defaults
+        builtin_known_actions()
+            .get(action_uses)
+            .map(|w| w.to_vec())
     }
 }
 

--- a/src/support/workflows.rs
+++ b/src/support/workflows.rs
@@ -238,6 +238,61 @@ fn ref_is_untrusted(s: &str) -> bool {
     lc.contains("pull_request.head") || lc.contains("head_ref")
 }
 
+/// Collect every `uses:` value from the given job's steps.
+pub fn job_action_uses(doc: &Value, job_name: &str) -> Vec<String> {
+    let Value::Mapping(top) = doc else {
+        return Vec::new();
+    };
+    let Some(Value::Mapping(jobs)) = top.get(Value::String("jobs".into())) else {
+        return Vec::new();
+    };
+    let Some(job) = jobs.get(Value::String(job_name.into())) else {
+        return Vec::new();
+    };
+    let Value::Mapping(jm) = job else {
+        return Vec::new();
+    };
+    let Some(Value::Sequence(steps)) = jm.get(Value::String("steps".into())) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for step in steps {
+        if let Value::Mapping(step_map) = step
+            && let Some(Value::String(uses)) = step_map.get(Value::String("uses".into()))
+        {
+            out.push(uses.clone());
+        }
+    }
+    out
+}
+
+pub fn job_uses_action(doc: &Value, job_name: &str, action_prefix: &str) -> bool {
+    let Value::Mapping(top) = doc else {
+        return false;
+    };
+    let Some(Value::Mapping(jobs)) = top.get(Value::String("jobs".into())) else {
+        return false;
+    };
+    let Some(job) = jobs.get(Value::String(job_name.into())) else {
+        return false;
+    };
+    let Value::Mapping(jm) = job else {
+        return false;
+    };
+    let Some(Value::Sequence(steps)) = jm.get(Value::String("steps".into())) else {
+        return false;
+    };
+    for step in steps {
+        if let Value::Mapping(step_map) = step
+            && let Some(Value::String(uses)) = step_map.get(Value::String("uses".into()))
+            && uses.starts_with(action_prefix)
+        {
+            return true;
+        }
+    }
+    false
+}
+
 pub enum PermissionsBlock<'a> {
     Missing,
     WriteAll,

--- a/tests/checks_repos.rs
+++ b/tests/checks_repos.rs
@@ -1165,6 +1165,107 @@ fn workflow_perms_job_level_read_only_passes() {
     assert_eq!(workflow_perms::repo_check(&c).status, Status::Pass);
 }
 
+#[test]
+fn workflow_perms_deploy_pages_job_with_required_writes_passes() {
+    let mut c = ctx(BranchProtectionState::Unprotected, WorkflowTokenState::Read);
+    c.workflows = bw(vec![wf(
+        "deploy.yml",
+        "on: push\npermissions:\n  contents: read\njobs:\n  deploy:\n    permissions:\n      pages: write\n      id-token: write\n    steps:\n      - uses: actions/deploy-pages@0000000000000000000000000000000000000000\n",
+    )]);
+    assert_eq!(workflow_perms::repo_check(&c).status, Status::Pass);
+}
+
+#[test]
+fn workflow_perms_deploy_pages_job_with_extra_writes_fails() {
+    let mut c = ctx(BranchProtectionState::Unprotected, WorkflowTokenState::Read);
+    c.workflows = bw(vec![wf(
+        "deploy.yml",
+        "on: push\npermissions:\n  contents: read\njobs:\n  deploy:\n    permissions:\n      pages: write\n      id-token: write\n      contents: write\n    steps:\n      - uses: actions/deploy-pages@ffffffffffffffffffffffffffffffffffffffff\n",
+    )]);
+    let o = workflow_perms::repo_check(&c);
+    assert_eq!(o.status, Status::Fail);
+    assert!(o.items.iter().any(|i| i.contains("contents")));
+}
+
+#[test]
+fn workflow_perms_deploy_pages_job_top_level_write_still_fails() {
+    let mut c = ctx(BranchProtectionState::Unprotected, WorkflowTokenState::Read);
+    c.workflows = bw(vec![wf(
+        "deploy.yml",
+        "on: push\npermissions:\n  contents: write\njobs:\n  deploy:\n    permissions:\n      pages: write\n      id-token: write\n    steps:\n      - uses: actions/deploy-pages@1111111111111111111111111111111111111111\n",
+    )]);
+    let o = workflow_perms::repo_check(&c);
+    assert_eq!(o.status, Status::Fail);
+    assert!(o.items.iter().any(|i| i.contains("contents")));
+}
+
+#[test]
+fn workflow_perms_deploy_pages_full_user_workflow_passes() {
+    let mut c = ctx(BranchProtectionState::Unprotected, WorkflowTokenState::Read);
+    c.workflows = bw(vec![wf(
+        "deploy.yml",
+        r#"on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      - run: echo build
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+"#,
+    )]);
+    assert_eq!(workflow_perms::repo_check(&c).status, Status::Pass);
+}
+
+#[test]
+fn workflow_perms_deploy_pages_job_without_action_still_fails() {
+    let mut c = ctx(BranchProtectionState::Unprotected, WorkflowTokenState::Read);
+    c.workflows = bw(vec![wf(
+        "deploy.yml",
+        "on: push\npermissions:\n  contents: read\njobs:\n  deploy:\n    permissions:\n      pages: write\n    steps:\n      - run: echo\n",
+    )]);
+    let o = workflow_perms::repo_check(&c);
+    assert_eq!(o.status, Status::Fail);
+    assert!(o.items.iter().any(|i| i.contains("pages")));
+}
+
+#[test]
+fn workflow_perms_custom_known_action_from_config_passes() {
+    let config = moat::config::Config::parse(
+        r#"
+            [workflow_permissions]
+            "my-org/custom-deploy" = ["deployments"]
+        "#,
+        &[],
+    )
+    .unwrap();
+    let mut c = ctx(BranchProtectionState::Unprotected, WorkflowTokenState::Read);
+    c.config = config;
+    c.workflows = bw(vec![wf(
+        "deploy.yml",
+        "on: push\npermissions:\n  contents: read\njobs:\n  deploy:\n    permissions:\n      deployments: write\n    steps:\n      - uses: my-org/custom-deploy@v1\n",
+    )]);
+    assert_eq!(workflow_perms::repo_check(&c).status, Status::Pass);
+}
+
 #[tokio::test]
 async fn repo_context_fetch_bails_on_forbidden_workflow_token() {
     let client =


### PR DESCRIPTION
- Introduced exemption mechanism for actions requiring specific write permissions (e.g., `actions/deploy-pages` needing `pages: write`).
- Added `workflow_permissions_known_actions` to `Config` structure for user-defined action exemptions via `moat.toml`.
- Implemented filtering logic to exclude recognized write scopes from findings.
- Updated tests to validate exemptions for both built-in and user-configured actions.
- Enhanced `README.md` with documentation about known action exemptions and configuration options.

Resolves #27 